### PR TITLE
Add download URL to torrent files

### DIFF
--- a/src/reducers/socket.js
+++ b/src/reducers/socket.js
@@ -3,14 +3,15 @@ import { SOCKET_STATE, SOCKET_UPDATE, SOCKET_URI } from '../actions/socket';
 export default function socket(_state = {
   state: SOCKET_STATE.DISCONNECTED,
   reason: null,
-  uri: null
+  uri: null,
+  password: null,
 }, action) {
   const { state, reason, uri } = action;
   switch (action.type) {
     case SOCKET_UPDATE:
       return { ..._state, state, reason };
     case SOCKET_URI:
-      return { ..._state, uri };
+      return { ..._state, ...uri, };
     default:
       return _state;
   }

--- a/src/socket.js
+++ b/src/socket.js
@@ -7,6 +7,9 @@ let transactions = {};
 let connected = false;
 let queue = [];
 
+const getURI = ({ uri, password }) => `${uri}${password ?
+  `?password=${encodeURIComponent(password)}` : ''}`;
+
 export default function ws_send(type, body, callback = null) {
   const _serial = serial++;
   if (callback) {
@@ -43,7 +46,7 @@ function ws_recv(e) {
 }
 
 export function ws_init(uri, open, close) {
-  ws = new WebSocket(uri);
+  ws = new WebSocket(getURI(uri));
   ws.addEventListener("open", () => {
     connected = true;
     open.apply(this, arguments);

--- a/src/ui/connection.js
+++ b/src/ui/connection.js
@@ -13,8 +13,7 @@ import {
 import { initialize } from '..';
 import { SOCKET_STATE } from '../actions/socket';
 
-const getURI = (uri, password) => `${uri}${password ?
-  `?password=${encodeURIComponent(password)}` : ''}`;
+const getURI = (uri, password) => ({ uri, password });
 
 class ConnectionOverlay extends Component {
   constructor() {

--- a/src/ui/torrent_details.js
+++ b/src/ui/torrent_details.js
@@ -15,6 +15,7 @@ import moment from 'moment';
 import TorrentOptions from './torrent_options';
 import TorrentProgress from './torrent_progress';
 import ws_send from '../socket';
+import store from '../store';
 import DateDisplay from './date';
 import selectTorrent, {
   EXCLUSIVE,
@@ -24,12 +25,19 @@ import selectTorrent, {
 } from '../actions/selection';
 import { updateResource } from '../actions/resources';
 
+const dlURI = (uri, password, id) => `${uri.replace('ws', 'http')}/dl/${id}?password=${encodeURIComponent(password)}`;
+
 function File({ file }) {
   // TODO: show progress bar
   // TODO: edit priority
+  const { uri, password } = store.getState().socket;
   return (
     <tr>
-      <td>{file.path}</td>
+      <td>
+        <a href={dlURI(uri, password, file.id)} target="_new">
+          {file.path}
+        </a>
+      </td>
       <td>{file.priority}</td>
       <td>{file.availability}</td>
     </tr>


### PR DESCRIPTION
This also moves out URI encoding to the final step in the socket connection.

I'm not sure I like doing the `.replace('ws', 'http')`, it may be better to use some sort of proper URI manipulation library, but it's probably fine for now.