### PR TITLE
Fix minor UI rendering regressions

### DIFF
--- a/src/ui/torrent_details.js
+++ b/src/ui/torrent_details.js
@@ -130,6 +130,7 @@ class Torrent extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     return nextProps.torrent !== this.props.torrent
+      || nextState.removeDropdown !== this.state.removeDropdown
       || nextState.peersShown !== this.state.peersShown
       || nextState.trackersShown !== this.state.trackersShown
       || nextState.filesShown !== this.state.filesShown

--- a/src/ui/torrent_table.js
+++ b/src/ui/torrent_table.js
@@ -18,11 +18,7 @@ class _Torrent extends Component {
     const nt = nextProps.torrent;
     const active = selection.indexOf(torrent.id);
     const nActive = nextProps.selection.indexOf(torrent.id);
-    return active !== nActive
-      || torrent.id !== nt.id
-      || torrent.status !== nt.status
-      || torrent.rate_down !== nt.rate_down
-      || torrent.rate_up !== nt.rate_up;
+    return active !== nActive || torrent !== nt;
   }
 
   render() {


### PR DESCRIPTION
Some of the re-rendering logic wasn't quite right, causing the removal button to not work and torrents to not render as frequently as they should have.